### PR TITLE
Django Forms schema field

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ class Foo(pydantic.BaseModel):
 
 
 class FooForm(forms.Form):
-    field = SchemaField(Foo)  # `typing.ForwardRef("Foo")` is also fine
+    field = SchemaField(Foo)  # `typing.ForwardRef("Foo")` is fine too
 
 
 form = FooMForm(data={"field": '{"slug": "asdf"}'})
@@ -123,6 +123,8 @@ form = AnotherFooModelForm(data={"field": '{"slug": "bar_baz"}'})
 assert form.is_valid()
 assert form.cleaned_data["field"] == Foo(slug="bar_baz")
 ```
+
+Note, that forward references would be resolved until field is being bound to the form instance.
 
 ## Django REST Framework support
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,50 @@ class Bar(pydantic.BaseModel):
 In this case, exact type resolution will be postponed until initial access to the field.
 Usually this happens on the first instantiation of the model.
 
+## Django Forms support
+
+It is possible to create Django forms, which would validate against the given schema:
+
+``` python
+from django import forms
+from django_pydantic_field.forms import SchemaField
+
+
+class Foo(pydantic.BaseModel):
+    slug: str = "foo_bar"
+
+
+class FooForm(forms.Form):
+    field = SchemaField(Foo)  # `typing.ForwardRef("Foo")` is also fine
+
+
+form = FooMForm(data={"field": '{"slug": "asdf"}'})
+assert form.is_valid()
+assert form.cleaned_data["field"] == Foo(slug="asdf")
+```
+
+`django_pydantic_field` also supports auto-generated fields for `ModelForm` and `modelform_factory`:
+
+``` python
+class FooModelForm(forms.ModelForm):
+    class Meta:
+        model = Foo
+        fields = ["field"]
+
+form = FooModelForm(data={"field": '{"slug": "asdf"}'})
+assert form.is_valid()
+assert form.cleaned_data["field"] == Foo(slug="asdf")
+
+...
+
+# ModelForm factory support
+AnotherFooModelForm = modelform_factory(Foo, fields=["field"])
+form = AnotherFooModelForm(data={"field": '{"slug": "bar_baz"}'})
+
+assert form.is_valid()
+assert form.cleaned_data["field"] == Foo(slug="bar_baz")
+```
+
 ## Django REST Framework support
 
 ``` python

--- a/django_pydantic_field/base.py
+++ b/django_pydantic_field/base.py
@@ -73,7 +73,7 @@ class SchemaDecoder(t.Generic[ST]):
 
 
 def wrap_schema(
-    schema: t.Type["ST"],
+    schema: t.Union[t.Type["ST"], t.ForwardRef],
     config: t.Optional["ConfigType"] = None,
     allow_null: bool = False,
     **kwargs,
@@ -101,16 +101,11 @@ def extract_export_kwargs(ctx: dict, extractor=dict.get):
     return {k: v for k, v in export_ctx.items() if v is not None}
 
 
-def _get_field_schema_name(schema: t.Type[t.Any]) -> str:
+def _get_field_schema_name(schema) -> str:
     return f"FieldSchema[{display_as_type(schema)}]"
 
 
-def _get_field_schema_params(
-    schema: t.Type["ST"],
-    config: t.Optional["ConfigType"] = None,
-    allow_null: bool = False,
-    **kwargs,
-) -> dict:
+def _get_field_schema_params(schema, config=None, allow_null=False, **kwargs) -> dict:
     root_model = t.Optional[schema] if allow_null else schema
     params: t.Dict[str, t.Any] = dict(kwargs, __root__=(root_model, ...))
     parent_config = getattr(schema, "Config", None)

--- a/django_pydantic_field/fields.py
+++ b/django_pydantic_field/fields.py
@@ -131,7 +131,7 @@ class PydanticSchemaField(JSONField, t.Generic[base.ST]):
     def _prepare_model_schema(self, cls=None):
         cls = cls or getattr(self, "model", None)
         if cls is not None:
-            model_ns = utils.get_model_namespace(cls)
+            model_ns = utils.get_local_namespace(cls)
             self.serializer_schema.update_forward_refs(**model_ns)
             self.is_prepared_schema = True
 

--- a/django_pydantic_field/fields.py
+++ b/django_pydantic_field/fields.py
@@ -166,7 +166,7 @@ if t.TYPE_CHECKING:
 
 @t.overload
 def SchemaField(
-    schema: "t.Union[t.Type[base.ST], t.ForwardRef, str]" = ...,
+    schema: "t.Union[t.Type[base.ST], t.ForwardRef]" = ...,
     config: "base.ConfigType" = ...,
     default: "t.Union[OptSchemaT, t.Callable[[], OptSchemaT]]" = ...,
     *args,
@@ -177,7 +177,7 @@ def SchemaField(
 
 @t.overload
 def SchemaField(
-    schema: "t.Union[t.Type[base.ST], t.ForwardRef, str]" = ...,
+    schema: "t.Union[t.Type[base.ST], t.ForwardRef]" = ...,
     config: "base.ConfigType" = ...,
     default: "t.Union[base.SchemaT, t.Callable[[], base.SchemaT]]" = ...,
     *args,

--- a/django_pydantic_field/form.py
+++ b/django_pydantic_field/form.py
@@ -1,0 +1,47 @@
+import pydantic
+import typing as t
+from functools import partial
+
+from django.core.exceptions import ValidationError
+from django.forms.fields import JSONField, InvalidJSONInput
+
+from . import base
+
+__all__ = ("SchemaField",)
+
+
+class SchemaField(JSONField, t.Generic[base.ST]):
+    decoder: base.SchemaDecoder[base.ST]
+    encoder: base.SchemaEncoder
+
+    def __init__(
+        self,
+        schema: t.Type["base.ST"],
+        config: t.Optional["base.ConfigType"] = None,
+        **kwargs
+    ):
+        allow_null = not kwargs.get("required", True)
+        bound_schema = base.wrap_schema(schema, config, allow_null)
+        export_params = base.extract_export_kwargs(kwargs)
+
+        decoder = partial(base.SchemaDecoder, bound_schema)
+        encoder = partial(
+            base.SchemaEncoder,
+            schema=bound_schema,
+            export=export_params,
+            raise_errors=True,
+        )
+        kwargs.update(encoder=encoder, decoder=decoder)
+        super().__init__(**kwargs)
+
+    def to_python(self, value):
+        try:
+            return super().to_python(value)
+        except pydantic.ValidationError as e:
+            raise ValidationError(e.errors(), code="invalid")
+
+    def bound_data(self, data, initial):
+        try:
+            return super().bound_data(data, initial)
+        except pydantic.ValidationError as e:
+            return InvalidJSONInput(data)

--- a/django_pydantic_field/forms.py
+++ b/django_pydantic_field/forms.py
@@ -11,19 +11,18 @@ __all__ = ("SchemaField",)
 
 
 class SchemaField(JSONField, t.Generic[base.ST]):
-    decoder: base.SchemaDecoder[base.ST]
-    encoder: base.SchemaEncoder
-
     def __init__(
         self,
         schema: t.Type["base.ST"],
         config: t.Optional["base.ConfigType"] = None,
+        __module__: str = None,
         **kwargs
     ):
         allow_null = not kwargs.get("required", True)
-        bound_schema = base.wrap_schema(schema, config, allow_null)
-        export_params = base.extract_export_kwargs(kwargs)
+        bound_schema = base.wrap_schema(schema, config, allow_null, __module__=__module__)
+        bound_schema.update_forward_refs()
 
+        export_params = base.extract_export_kwargs(kwargs)
         decoder = partial(base.SchemaDecoder, bound_schema)
         encoder = partial(
             base.SchemaEncoder,

--- a/django_pydantic_field/forms.py
+++ b/django_pydantic_field/forms.py
@@ -5,28 +5,32 @@ from functools import partial
 from django.core.exceptions import ValidationError
 from django.forms.fields import JSONField, InvalidJSONInput
 
-from . import base
+from . import base, utils
 
 __all__ = ("SchemaField",)
 
 
 class SchemaField(JSONField, t.Generic[base.ST]):
+    _is_prepared_field: bool = False
+
     def __init__(
         self,
-        schema: t.Type["base.ST"],
+        schema: t.Union[t.Type["base.ST"], t.ForwardRef],
         config: t.Optional["base.ConfigType"] = None,
         __module__: str = None,
         **kwargs
     ):
-        allow_null = not kwargs.get("required", True)
-        bound_schema = base.wrap_schema(schema, config, allow_null, __module__=__module__)
-        bound_schema.update_forward_refs()
-
+        self.schema = base.wrap_schema(
+            schema,
+            config,
+            allow_null=not kwargs.get("required", True),
+            __module__=__module__,
+        )
         export_params = base.extract_export_kwargs(kwargs)
-        decoder = partial(base.SchemaDecoder, bound_schema)
+        decoder = partial(base.SchemaDecoder, self.schema)
         encoder = partial(
             base.SchemaEncoder,
-            schema=bound_schema,
+            schema=self.schema,
             export=export_params,
             raise_errors=True,
         )
@@ -44,3 +48,13 @@ class SchemaField(JSONField, t.Generic[base.ST]):
             return super().bound_data(data, initial)
         except pydantic.ValidationError as e:
             return InvalidJSONInput(data)
+
+    def get_bound_field(self, form, field_name):
+        if not self._is_prepared_field:
+            self._prepare_field(form)
+        return super().get_bound_field(form, field_name)
+
+    def _prepare_field(self, form):
+        form_ns = utils.get_local_namespace(form)
+        self.schema.update_forward_refs(**form_ns)
+        self._is_prepared_field = True

--- a/django_pydantic_field/utils.py
+++ b/django_pydantic_field/utils.py
@@ -10,7 +10,7 @@ def get_annotated_type(cls, field, default=None) -> t.Any:
         return default
 
 
-def get_model_namespace(cls) -> t.Dict[str, t.Any]:
+def get_local_namespace(cls) -> t.Dict[str, t.Any]:
     module = cls.__module__
     try:
         return vars(sys.modules[module])

--- a/tests/sample_app/models.py
+++ b/tests/sample_app/models.py
@@ -16,7 +16,7 @@ class Building(models.Model):
     opt_meta: t.Optional["BuildingMeta"] = SchemaField(default={"type": "frame"}, null=True)
     meta: "BuildingMeta" = SchemaField(default={"type": "frame"})
 
-    meta_schema_list = SchemaField(schema="t.List[BuildingMeta]", default=list)
+    meta_schema_list = SchemaField(schema=t.ForwardRef("t.List[BuildingMeta]"), default=list)
     meta_typing_list: t.List["BuildingMeta"] = SchemaField(default=list)
     meta_untyped_list: list = SchemaField(schema=t.List, default=list)
     meta_untyped_builtin_list: t.List = SchemaField(schema=list, default=list)

--- a/tests/test_form_field.py
+++ b/tests/test_form_field.py
@@ -1,25 +1,40 @@
 import pytest
+import pydantic
+import typing as t
 
 from django.core.exceptions import ValidationError
-from django_pydantic_field.form import SchemaField
+from django.db import models
+from django.forms import modelform_factory
+from django_pydantic_field import forms, fields
 
 from .conftest import InnerSchema
 
 
+class SampleForwardRefFieldModel(models.Model):
+    annotated_field: t.Optional["SampleSchema"] = fields.SchemaField(null=True)
+
+    class Meta:
+        app_label = "test_app"
+
+
+class SampleSchema(pydantic.BaseModel):
+    field: int = 1
+
+
 def test_form_schema_field():
-    field = SchemaField(InnerSchema)
+    field = forms.SchemaField(InnerSchema)
 
     cleaned_data =  field.clean('{"stub_str": "abc", "stub_list": ["1970-01-01"]}')
     assert cleaned_data == InnerSchema.parse_obj({"stub_str": "abc", "stub_list": ["1970-01-01"]})
 
 def test_empty_form_values():
-    field = SchemaField(InnerSchema, required=False)
+    field = forms.SchemaField(InnerSchema, required=False)
     assert field.clean("") is None
     assert field.clean(None) is None
 
 
 def test_invalid_raises():
-    field = SchemaField(InnerSchema)
+    field = forms.SchemaField(InnerSchema)
     with pytest.raises(ValidationError) as e:
         field.clean("")
 
@@ -30,3 +45,19 @@ def test_invalid_raises():
 
     assert e.match("stub_str")
     assert e.match("stub_list")
+
+
+def test_model_formfield():
+    field = fields.PydanticSchemaField(schema=InnerSchema)
+    assert isinstance(field.formfield(), forms.SchemaField)
+
+
+def test_forwardref_model_formfield():
+    form_cls = modelform_factory(SampleForwardRefFieldModel, exclude=())
+    form = form_cls(data={"annotated_field": '{"field": "2"}'})
+
+    assert form.is_valid()
+    cleaned_data = form.cleaned_data
+
+    assert cleaned_data is not None
+    assert cleaned_data["annotated_field"] == SampleSchema(field=2)

--- a/tests/test_form_field.py
+++ b/tests/test_form_field.py
@@ -1,0 +1,32 @@
+import pytest
+
+from django.core.exceptions import ValidationError
+from django_pydantic_field.form import SchemaField
+
+from .conftest import InnerSchema
+
+
+def test_form_schema_field():
+    field = SchemaField(InnerSchema)
+
+    cleaned_data =  field.clean('{"stub_str": "abc", "stub_list": ["1970-01-01"]}')
+    assert cleaned_data == InnerSchema.parse_obj({"stub_str": "abc", "stub_list": ["1970-01-01"]})
+
+def test_empty_form_values():
+    field = SchemaField(InnerSchema, required=False)
+    assert field.clean("") is None
+    assert field.clean(None) is None
+
+
+def test_invalid_raises():
+    field = SchemaField(InnerSchema)
+    with pytest.raises(ValidationError) as e:
+        field.clean("")
+
+    assert e.match("This field is required")
+
+    with pytest.raises(ValidationError) as e:
+        field.clean('{"stub_list": "abc"}')
+
+    assert e.match("stub_str")
+    assert e.match("stub_list")

--- a/tests/test_form_field.py
+++ b/tests/test_form_field.py
@@ -4,7 +4,7 @@ import typing as t
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.forms import modelform_factory
+from django.forms import Form, modelform_factory
 from django_pydantic_field import forms, fields
 
 from .conftest import InnerSchema
@@ -15,6 +15,10 @@ class SampleForwardRefFieldModel(models.Model):
 
     class Meta:
         app_label = "test_app"
+
+
+class SampleForm(Form):
+    field = forms.SchemaField(t.ForwardRef("SampleSchema"))
 
 
 class SampleSchema(pydantic.BaseModel):
@@ -45,6 +49,11 @@ def test_invalid_raises():
 
     assert e.match("stub_str")
     assert e.match("stub_list")
+
+
+def test_forwardref_field():
+    form = SampleForm(data={"field": '{"field": "2"}'})
+    assert form.is_valid()
 
 
 def test_model_formfield():


### PR DESCRIPTION
This PR adds SchemaField support for Django Forms. This class adds schema validations decoupled from model fields themselves. It semantically equivalent to `forms.JSONField`.

- [x] Implement main form field class.
- [x] Possibility to resolve forward references.
- [x] Autogenerated fields for `ModelForm`s.