### PR TITLE
Python 3.7 + Django 3.2 support

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tmp/
 
 dist/
 .env*/
+.venv*/
 .mypy_cache/
 *.py[cod]
 *.egg

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 tmp/
 
 dist/
-.env/
+.env*/
 .mypy_cache/
 *.py[cod]
 *.egg

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 
 .PHONY: install
 install:
-	python3 -m venv .env
-	. .env/bin/activate
 	python3 -m pip install build twine
 	python3 -m pip install -e .[dev,rest]
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ class Foo(pydantic.BaseModel):
 
 
 class FooForm(forms.Form):
-    field = SchemaField(Foo)  # `typing.ForwardRef("Foo")` is fine too
+    field = SchemaField(Foo)  # `typing.ForwardRef("Foo")` is fine too, but only in Django 4+
 
 
 form = FooMForm(data={"field": '{"slug": "asdf"}'})

--- a/django_pydantic_field/_migration_serializers.py
+++ b/django_pydantic_field/_migration_serializers.py
@@ -23,8 +23,8 @@ try:
 except ImportError:
     from typing_extensions import get_args, get_origin
 
+from django.db.migrations.serializer import BaseSerializer, serializer_factory
 from django.db.migrations.writer import MigrationWriter
-from django.db.migrations.serializer import serializer_factory, BaseSerializer
 
 
 class GenericContainer:

--- a/django_pydantic_field/_migration_serializers.py
+++ b/django_pydantic_field/_migration_serializers.py
@@ -18,6 +18,11 @@ import sys
 import types
 import typing as t
 
+try:
+    from typing import get_args, get_origin
+except ImportError:
+    from typing_extensions import get_args, get_origin
+
 from django.db.migrations.writer import MigrationWriter
 from django.db.migrations.serializer import serializer_factory, BaseSerializer
 
@@ -31,7 +36,7 @@ class GenericContainer:
 
     @classmethod
     def from_generic(cls, type_alias):
-        return cls(t.get_origin(type_alias), t.get_args(type_alias))
+        return cls(get_origin(type_alias), get_args(type_alias))
 
     def reconstruct_type(self):
         if not self.args:
@@ -120,7 +125,7 @@ if sys.version_info >= (3, 10):
             if isinstance(self.value, type(t.Union)):  # type: ignore
                 imports.add("import typing")
 
-            for arg in t.get_args(self.value):
+            for arg in get_args(self.value):
                 _, arg_imports = serializer_factory(arg).serialize()
                 imports.update(arg_imports)
 

--- a/django_pydantic_field/base.py
+++ b/django_pydantic_field/base.py
@@ -1,8 +1,7 @@
 import typing as t
 
-from django.core.serializers.json import DjangoJSONEncoder
-
 import pydantic
+from django.core.serializers.json import DjangoJSONEncoder
 from pydantic.config import get_config, inherit_config
 from pydantic.typing import display_as_type
 
@@ -17,7 +16,6 @@ __all__ = (
 )
 
 ST = t.TypeVar("ST", bound="SchemaT")
-_RESOLVED_FORWARD_REF_FLAG = "__resolved_forwardrefs__"
 
 if t.TYPE_CHECKING:
     from pydantic.dataclasses import DataclassClassOrWrapper
@@ -88,10 +86,8 @@ def wrap_schema(
 
 
 def prepare_schema(schema: "ModelType", owner: t.Any = None) -> None:
-    if not getattr(schema, _RESOLVED_FORWARD_REF_FLAG, False):
-        namespace = get_local_namespace(owner)
-        schema.update_forward_refs(**namespace)
-        setattr(schema, _RESOLVED_FORWARD_REF_FLAG, True)
+    namespace = get_local_namespace(owner)
+    schema.update_forward_refs(**namespace)
 
 
 def extract_export_kwargs(ctx: dict, extractor=dict.get) -> t.Dict[str, t.Any]:

--- a/django_pydantic_field/fields.py
+++ b/django_pydantic_field/fields.py
@@ -98,12 +98,12 @@ class PydanticSchemaField(JSONField, t.Generic[base.ST]):
         if self.schema is None:
             self._resolve_schema_from_type_hints(self.model, self.attname)
 
-        bound_model = getattr(self, "model", None)
+        owner_model = getattr(self, "model", None)
         field_kwargs = dict(
             form_class=forms.SchemaField,
             schema=self.schema,
             config=self.config,
-            __module__=getattr(bound_model, "__module__", None),
+            __module__=getattr(owner_model, "__module__", None),
             **self.export_params,
         )
         field_kwargs.update(kwargs)
@@ -131,8 +131,7 @@ class PydanticSchemaField(JSONField, t.Generic[base.ST]):
     def _prepare_model_schema(self, cls=None):
         cls = cls or getattr(self, "model", None)
         if cls is not None:
-            model_ns = utils.get_local_namespace(cls)
-            self.serializer_schema.update_forward_refs(**model_ns)
+            base.prepare_schema(self.serializer_schema, cls)
             self.is_prepared_schema = True
 
     def _deconstruct_default(self, kwargs):

--- a/django_pydantic_field/fields.py
+++ b/django_pydantic_field/fields.py
@@ -1,15 +1,14 @@
 import json
 import typing as t
-import pydantic
-
 from functools import partial
 
+import pydantic
 from django.core import exceptions as django_exceptions
 from django.db.models.fields import NOT_PROVIDED
 from django.db.models.fields.json import JSONField
 from django.db.models.query_utils import DeferredAttribute
 
-from . import base, utils, forms
+from . import base, forms, utils
 from ._migration_serializers import GenericContainer, GenericTypes
 
 __all__ = ("SchemaField",)

--- a/django_pydantic_field/forms.py
+++ b/django_pydantic_field/forms.py
@@ -5,14 +5,12 @@ from functools import partial
 from django.core.exceptions import ValidationError
 from django.forms.fields import JSONField, InvalidJSONInput
 
-from . import base, utils
+from . import base
 
 __all__ = ("SchemaField",)
 
 
 class SchemaField(JSONField, t.Generic[base.ST]):
-    _is_prepared_field: bool = False
-
     def __init__(
         self,
         schema: t.Union[t.Type["base.ST"], t.ForwardRef],
@@ -46,15 +44,9 @@ class SchemaField(JSONField, t.Generic[base.ST]):
     def bound_data(self, data, initial):
         try:
             return super().bound_data(data, initial)
-        except pydantic.ValidationError as e:
+        except pydantic.ValidationError:
             return InvalidJSONInput(data)
 
     def get_bound_field(self, form, field_name):
-        if not self._is_prepared_field:
-            self._prepare_field(form)
+        base.prepare_schema(self.schema, form)
         return super().get_bound_field(form, field_name)
-
-    def _prepare_field(self, form):
-        form_ns = utils.get_local_namespace(form)
-        self.schema.update_forward_refs(**form_ns)
-        self._is_prepared_field = True

--- a/django_pydantic_field/forms.py
+++ b/django_pydantic_field/forms.py
@@ -1,9 +1,9 @@
-import pydantic
 import typing as t
 from functools import partial
 
+import pydantic
 from django.core.exceptions import ValidationError
-from django.forms.fields import JSONField, InvalidJSONInput
+from django.forms.fields import InvalidJSONInput, JSONField
 
 from . import base
 
@@ -15,7 +15,7 @@ class SchemaField(JSONField, t.Generic[base.ST]):
         self,
         schema: t.Union[t.Type["base.ST"], t.ForwardRef],
         config: t.Optional["base.ConfigType"] = None,
-        __module__: str = None,
+        __module__: t.Optional[str] = None,
         **kwargs
     ):
         self.schema = base.wrap_schema(

--- a/django_pydantic_field/utils.py
+++ b/django_pydantic_field/utils.py
@@ -2,29 +2,21 @@ import sys
 import typing as t
 
 
-def get_annotated_type(cls, field, default=None) -> t.Any:
+def get_annotated_type(obj, field, default=None) -> t.Any:
     try:
-        annotations = cls.__annotations__
+        if isinstance(obj, type):
+            annotations = obj.__dict__["__annotations__"]
+        else:
+            annotations = obj.__annotations__
+
         return annotations[field]
     except (AttributeError, KeyError):
         return default
 
 
 def get_local_namespace(cls) -> t.Dict[str, t.Any]:
-    module = cls.__module__
     try:
+        module = cls.__module__
         return vars(sys.modules[module])
-    except KeyError:
+    except (KeyError, AttributeError):
         return {}
-
-
-def is_forward_ref(type_):
-    if isinstance(type_, (str, t.ForwardRef)):
-        return True
-
-    origin = t.get_origin(type_)
-    if origin is None:
-        return False
-
-    type_args = t.get_args(type_)
-    return is_forward_ref(origin) or any(map(is_forward_ref, type_args))

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,8 @@ rest =
 
 dev =
     black
-    mypy==0.961
-    flake8==4.0.*
+    isort
+    mypy
     pytest==7.0.*
     djangorestframework>=3.11,<4
     django-stubs[compatible-mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,16 +21,18 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.7
 packages = django_pydantic_field
 install_requires =
     pydantic>=1.9,<2
-    django>=4.0,<5
+    django>=3.0,<5
+    typing_extensions
 
 [options.extras_require]
 rest =
@@ -42,7 +44,7 @@ dev =
     mypy==0.961
     flake8==4.0.*
     pytest==7.0.*
-    djangorestframework>=3.13,<4
+    djangorestframework>=3.11,<4
     django-stubs[compatible-mypy]
     djangorestframework-stubs[compatible-mypy]
     pytest-django>=4.5,<5

--- a/tests/test_base_marshalling.py
+++ b/tests/test_base_marshalling.py
@@ -10,7 +10,6 @@ import pydantic
 from django_pydantic_field import base
 from .conftest import InnerSchema, SampleDataclass
 
-dummy = object()
 
 class SampleSchema(pydantic.BaseModel):
     __root__: InnerSchema

--- a/tests/test_base_marshalling.py
+++ b/tests/test_base_marshalling.py
@@ -1,5 +1,4 @@
 import typing as t
-import inspect
 import sys
 
 from datetime import date
@@ -11,6 +10,7 @@ import pydantic
 from django_pydantic_field import base
 from .conftest import InnerSchema, SampleDataclass
 
+dummy = object()
 
 class SampleSchema(pydantic.BaseModel):
     __root__: InnerSchema
@@ -117,3 +117,18 @@ def test_concrete_raw_types(type_factory, encoded, decoded):
 
     existing_encoded = encoder.encode(decoded)
     assert decoder.decode(existing_encoded) == decoded
+
+
+@pytest.mark.parametrize("forward_ref, sample_data", [
+    (t.ForwardRef("t.List[int]"), '[1, 2]'),
+    (t.ForwardRef("InnerSchema"), '{"stub_str": "abc", "stub_int": 1, "stub_list": ["2022-07-01"]}'),
+    (t.ForwardRef("PostponedSchema"), '{"stub_str": "abc", "stub_int": 1, "stub_list": ["2022-07-01"]}'),
+])
+def test_forward_refs_preparation(forward_ref, sample_data):
+    schema = base.wrap_schema(forward_ref)
+    base.prepare_schema(schema, test_forward_refs_preparation)
+    assert schema.parse_raw(sample_data).json() == sample_data
+
+
+class PostponedSchema(pydantic.BaseModel):
+    __root__: InnerSchema

--- a/tests/test_form_field.py
+++ b/tests/test_form_field.py
@@ -1,6 +1,7 @@
 import pytest
 import pydantic
 import typing as t
+import django
 
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -51,6 +52,10 @@ def test_invalid_raises():
     assert e.match("stub_list")
 
 
+@pytest.mark.xfail(
+    django.VERSION[:2] <= (4, 0),
+    reason="Django < 4 has it's own feeling on bound fields resolution",
+)
 def test_forwardref_field():
     form = SampleForm(data={"field": '{"field": "2"}'})
     assert form.is_valid()

--- a/tests/test_form_field.py
+++ b/tests/test_form_field.py
@@ -53,7 +53,7 @@ def test_invalid_raises():
 
 
 @pytest.mark.xfail(
-    django.VERSION[:2] <= (4, 0),
+    django.VERSION[:2] < (4, 0),
     reason="Django < 4 has it's own feeling on bound fields resolution",
 )
 def test_forwardref_field():


### PR DESCRIPTION
As long as 3.7 still supported, at least for 06/2023, I think it has some sense to port the package.
This implies Django 3.2 support, which have some different semantics for Form fields initialization. 

I was unable to implement proper forward references resolution for raw form fields in Django 3.2 without dirty hacks with call stack, except of explicitly pass `__module__=` param to the field. So, if you need to support forward references for forms in 3.2 you may either rely on `ModelForm` field auto-generation or use a following scheme:
 ```python
from django import forms
from typing import ForwardRef
from django_pydantic_field.forms import SchemaField


class FooForm(forms.Form):
    field = SchemaField(ForwardRef("Foo"), __module__=__module__)


class Foo(pydantic.BaseModel):
    ...
```
In Django 4.0+, and **in 3.2 with `ModelForm` autogen**, this should not an issue.

From what I can tell, all other features are fine with updated test matrix.
Along with that, DRF schema fields, renderers and parsers now also using forward references resolution.