### PR TITLE
Add support for Django 4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-pydantic-field"
-version = "0.2.3"
+version = "0.2.4"
 description = "Django JSONField with Pydantic models as a Schema"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Django 4.2 has changed a bit of base JSONField's `get_prep_value()` semantics.
This PR aims to fix that behavior.