### PR TITLE
Properly override `get_prep_value` and `get_db_prep_value` methods for PydanticSchemaField

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-pydantic-field"
-version = "0.2.4"
+version = "0.2.5"
 description = "Django JSONField with Pydantic models as a Schema"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_django_model_field.py
+++ b/tests/test_django_model_field.py
@@ -1,8 +1,10 @@
+import json
 import sys
 import typing as t
 from collections import abc
 from datetime import date
 
+import django
 import pytest
 from django.core.exceptions import FieldError, ValidationError
 from django.db import models
@@ -10,13 +12,16 @@ from django.db.migrations.writer import MigrationWriter
 from django_pydantic_field import fields
 
 from .conftest import InnerSchema, SampleDataclass
-from .test_app.models import SampleModel, SampleForwardRefModel, SampleSchema
+from .test_app.models import SampleForwardRefModel, SampleModel, SampleSchema
 
 
 def test_sample_field():
     sample_field = fields.PydanticSchemaField(schema=InnerSchema)
     existing_instance = InnerSchema(stub_str="abc", stub_list=[date(2022, 7, 1)])
-    expected_encoded = '{"stub_str": "abc", "stub_int": 1, "stub_list": ["2022-07-01"]}'
+
+    expected_encoded = {"stub_str": "abc", "stub_int": 1, "stub_list": ["2022-07-01"]}
+    if django.VERSION[:2] < (4, 2):
+        expected_encoded = json.dumps(expected_encoded)
 
     assert sample_field.get_prep_value(existing_instance) == expected_encoded
     assert sample_field.to_python(expected_encoded) == existing_instance
@@ -25,7 +30,10 @@ def test_sample_field():
 def test_sample_field_with_raw_data():
     sample_field = fields.PydanticSchemaField(schema=InnerSchema)
     existing_raw = {"stub_str": "abc", "stub_list": [date(2022, 7, 1)]}
-    expected_encoded = '{"stub_str": "abc", "stub_int": 1, "stub_list": ["2022-07-01"]}'
+
+    expected_encoded = {"stub_str": "abc", "stub_int": 1, "stub_list": ["2022-07-01"]}
+    if django.VERSION[:2] < (4, 2):
+        expected_encoded = json.dumps(expected_encoded)
 
     assert sample_field.get_prep_value(existing_raw) == expected_encoded
     assert sample_field.to_python(expected_encoded) == InnerSchema(**existing_raw)
@@ -44,7 +52,9 @@ def test_simple_model_field():
     existing_raw_field = {"stub_str": "abc", "stub_list": [date(2022, 7, 1)]}
     existing_raw_list = [{"stub_str": "abc", "stub_list": []}]
 
-    instance = SampleModel(sample_field=existing_raw_field, sample_list=existing_raw_list)
+    instance = SampleModel(
+        sample_field=existing_raw_field, sample_list=existing_raw_list
+    )
 
     expected_instance = InnerSchema(stub_str="abc", stub_list=[date(2022, 7, 1)])
     expected_list = [InnerSchema(stub_str="abc", stub_list=[])]
@@ -64,6 +74,7 @@ def test_null_field():
 
 def test_untyped_model_field_raises():
     with pytest.raises(FieldError):
+
         class UntypedModel(models.Model):
             sample_field = fields.SchemaField()
 
@@ -77,11 +88,9 @@ def test_forwardrefs_deferred_resolution():
     assert isinstance(obj.annotated_field, SampleSchema)
 
 
-@pytest.mark.parametrize("forward_ref", [
-    "InnerSchema",
-    t.ForwardRef("SampleDataclass"),
-    t.List["int"]
-])
+@pytest.mark.parametrize(
+    "forward_ref", ["InnerSchema", t.ForwardRef("SampleDataclass"), t.List["int"]]
+)
 def test_resolved_forwardrefs(forward_ref):
     class ModelWithForwardRefs(models.Model):
         field: forward_ref = fields.SchemaField()
@@ -90,87 +99,162 @@ def test_resolved_forwardrefs(forward_ref):
             app_label = "test_app"
 
 
-@pytest.mark.parametrize("field", [
-    fields.PydanticSchemaField(schema=InnerSchema, default=InnerSchema(stub_str="abc", stub_list=[date(2022, 7, 1)])),
-    fields.PydanticSchemaField(schema=InnerSchema, default=(("stub_str", "abc"), ("stub_list", [date(2022, 7, 1)]))),
-    fields.PydanticSchemaField(schema=InnerSchema, default={"stub_str": "abc", "stub_list": [date(2022, 7, 1)]}),
-    fields.PydanticSchemaField(schema=InnerSchema, null=True, default=None),
-    fields.PydanticSchemaField(schema=SampleDataclass, default={"stub_str": "abc", "stub_list": [date(2022, 7, 1)]}),
-    fields.PydanticSchemaField(schema=t.Optional[InnerSchema], null=True, default=None),
-])
+@pytest.mark.parametrize(
+    "field",
+    [
+        fields.PydanticSchemaField(
+            schema=InnerSchema,
+            default=InnerSchema(stub_str="abc", stub_list=[date(2022, 7, 1)]),
+        ),
+        fields.PydanticSchemaField(
+            schema=InnerSchema,
+            default=(("stub_str", "abc"), ("stub_list", [date(2022, 7, 1)])),
+        ),
+        fields.PydanticSchemaField(
+            schema=InnerSchema,
+            default={"stub_str": "abc", "stub_list": [date(2022, 7, 1)]},
+        ),
+        fields.PydanticSchemaField(schema=InnerSchema, null=True, default=None),
+        fields.PydanticSchemaField(
+            schema=SampleDataclass,
+            default={"stub_str": "abc", "stub_list": [date(2022, 7, 1)]},
+        ),
+        fields.PydanticSchemaField(
+            schema=t.Optional[InnerSchema], null=True, default=None
+        ),
+    ],
+)
 def test_field_serialization(field):
     _test_field_serialization(field)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="Built-in type subscription supports only in 3.9+")
-@pytest.mark.parametrize("field_factory", [
-    lambda: fields.PydanticSchemaField(schema=list[InnerSchema], default=list),
-    lambda: fields.PydanticSchemaField(schema=dict[str, InnerSchema], default=list),
-    lambda: fields.PydanticSchemaField(schema=abc.Sequence[InnerSchema], default=list),
-    lambda: fields.PydanticSchemaField(schema=abc.Mapping[str, InnerSchema], default=dict),
-])
+@pytest.mark.skipif(
+    sys.version_info < (3, 9), reason="Built-in type subscription supports only in 3.9+"
+)
+@pytest.mark.parametrize(
+    "field_factory",
+    [
+        lambda: fields.PydanticSchemaField(schema=list[InnerSchema], default=list),
+        lambda: fields.PydanticSchemaField(schema=dict[str, InnerSchema], default=list),
+        lambda: fields.PydanticSchemaField(
+            schema=abc.Sequence[InnerSchema], default=list
+        ),
+        lambda: fields.PydanticSchemaField(
+            schema=abc.Mapping[str, InnerSchema], default=dict
+        ),
+    ],
+)
 def test_field_builtin_annotations_serialization(field_factory):
     _test_field_serialization(field_factory())
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Union type syntax supported only in 3.10+")
+@pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="Union type syntax supported only in 3.10+"
+)
 def test_field_union_type_serialization():
-    field = fields.PydanticSchemaField(schema=(InnerSchema | None), null=True, default=None)
+    field = fields.PydanticSchemaField(
+        schema=(InnerSchema | None), null=True, default=None
+    )
     _test_field_serialization(field)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 9), reason="Should test against builtin generic types")
-@pytest.mark.parametrize("field", [
-    fields.PydanticSchemaField(schema=t.List[InnerSchema], default=list),
-    fields.PydanticSchemaField(schema=t.Dict[str, InnerSchema], default=list),
-    fields.PydanticSchemaField(schema=t.Sequence[InnerSchema], default=list),
-    fields.PydanticSchemaField(schema=t.Mapping[str, InnerSchema], default=dict),
-])
+@pytest.mark.skipif(
+    sys.version_info >= (3, 9), reason="Should test against builtin generic types"
+)
+@pytest.mark.parametrize(
+    "field",
+    [
+        fields.PydanticSchemaField(schema=t.List[InnerSchema], default=list),
+        fields.PydanticSchemaField(schema=t.Dict[str, InnerSchema], default=list),
+        fields.PydanticSchemaField(schema=t.Sequence[InnerSchema], default=list),
+        fields.PydanticSchemaField(schema=t.Mapping[str, InnerSchema], default=dict),
+    ],
+)
 def test_field_typing_annotations_serialization(field):
     _test_field_serialization(field)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="Typing-to-builtin migrations is reasonable only on py >= 3.9")
-@pytest.mark.parametrize("old_field, new_field", [
-    (
-        lambda: fields.PydanticSchemaField(schema=t.List[InnerSchema], default=list),
-        lambda: fields.PydanticSchemaField(schema=list[InnerSchema], default=list),
-    ), (
-        lambda: fields.PydanticSchemaField(schema=t.Dict[str, InnerSchema], default=list),
-        lambda: fields.PydanticSchemaField(schema=dict[str, InnerSchema], default=list),
-    ), (
-        lambda: fields.PydanticSchemaField(schema=t.Sequence[InnerSchema], default=list),
-        lambda: fields.PydanticSchemaField(schema=abc.Sequence[InnerSchema], default=list),
-    ), (
-        lambda: fields.PydanticSchemaField(schema=t.Mapping[str, InnerSchema], default=dict),
-        lambda: fields.PydanticSchemaField(schema=abc.Mapping[str, InnerSchema], default=dict),
-    ), (
-        lambda: fields.PydanticSchemaField(schema=t.Mapping[str, InnerSchema], default=dict),
-        lambda: fields.PydanticSchemaField(schema=abc.Mapping[str, InnerSchema], default=dict),
-    )
-])
+@pytest.mark.skipif(
+    sys.version_info < (3, 9),
+    reason="Typing-to-builtin migrations is reasonable only on py >= 3.9",
+)
+@pytest.mark.parametrize(
+    "old_field, new_field",
+    [
+        (
+            lambda: fields.PydanticSchemaField(
+                schema=t.List[InnerSchema], default=list
+            ),
+            lambda: fields.PydanticSchemaField(schema=list[InnerSchema], default=list),
+        ),
+        (
+            lambda: fields.PydanticSchemaField(
+                schema=t.Dict[str, InnerSchema], default=list
+            ),
+            lambda: fields.PydanticSchemaField(
+                schema=dict[str, InnerSchema], default=list
+            ),
+        ),
+        (
+            lambda: fields.PydanticSchemaField(
+                schema=t.Sequence[InnerSchema], default=list
+            ),
+            lambda: fields.PydanticSchemaField(
+                schema=abc.Sequence[InnerSchema], default=list
+            ),
+        ),
+        (
+            lambda: fields.PydanticSchemaField(
+                schema=t.Mapping[str, InnerSchema], default=dict
+            ),
+            lambda: fields.PydanticSchemaField(
+                schema=abc.Mapping[str, InnerSchema], default=dict
+            ),
+        ),
+        (
+            lambda: fields.PydanticSchemaField(
+                schema=t.Mapping[str, InnerSchema], default=dict
+            ),
+            lambda: fields.PydanticSchemaField(
+                schema=abc.Mapping[str, InnerSchema], default=dict
+            ),
+        ),
+    ],
+)
 def test_field_typing_to_builtin_serialization(old_field, new_field):
     old_field, new_field = old_field(), new_field()
 
     _, _, args, kwargs = old_field.deconstruct()
 
     reconstructed_field = fields.PydanticSchemaField(*args, **kwargs)
-    assert old_field.get_default() == new_field.get_default() == reconstructed_field.get_default()
+    assert (
+        old_field.get_default()
+        == new_field.get_default()
+        == reconstructed_field.get_default()
+    )
     assert new_field.schema == reconstructed_field.schema
 
     deserialized_field = reconstruct_field(serialize_field(old_field))
-    assert old_field.get_default() == deserialized_field.get_default() == new_field.get_default()
+    assert (
+        old_field.get_default()
+        == deserialized_field.get_default()
+        == new_field.get_default()
+    )
     assert new_field.schema == deserialized_field.schema
 
 
-@pytest.mark.parametrize("field, flawed_data", [
-    (fields.PydanticSchemaField(schema=InnerSchema), {}),
-    (fields.PydanticSchemaField(schema=t.List[InnerSchema]), [{}]),
-    (fields.PydanticSchemaField(schema=t.Dict[int, float]), {"1": "abc"}),
-])
+@pytest.mark.parametrize(
+    "field, flawed_data",
+    [
+        (fields.PydanticSchemaField(schema=InnerSchema), {}),
+        (fields.PydanticSchemaField(schema=t.List[InnerSchema]), [{}]),
+        (fields.PydanticSchemaField(schema=t.Dict[int, float]), {"1": "abc"}),
+    ],
+)
 def test_field_validation_exceptions(field, flawed_data):
     with pytest.raises(ValidationError):
         field.to_python(flawed_data)
+
 
 def test_model_validation_exceptions():
     with pytest.raises(ValidationError):
@@ -187,14 +271,17 @@ def test_model_validation_exceptions():
         valid_initial.sample_field = 1
 
 
-@pytest.mark.parametrize("export_kwargs", [
-    {"include": {"stub_str", "stub_int"}},
-    {"exclude": {"stub_list"}},
-    {"by_alias": True},
-    {"exclude_unset": True},
-    {"exclude_defaults": True},
-    {"exclude_none": True}
-])
+@pytest.mark.parametrize(
+    "export_kwargs",
+    [
+        {"include": {"stub_str", "stub_int"}},
+        {"exclude": {"stub_list"}},
+        {"by_alias": True},
+        {"exclude_unset": True},
+        {"exclude_defaults": True},
+        {"exclude_none": True},
+    ],
+)
 def test_export_kwargs_support(export_kwargs):
     field = fields.PydanticSchemaField(
         schema=InnerSchema,

--- a/tests/test_drf_adapters.py
+++ b/tests/test_drf_adapters.py
@@ -239,7 +239,7 @@ def test_openapi_serializer_schema_generation(request_factory):
     request = request_factory.get("api/", format="json")
     response = schema_view(request)
 
-    results = yaml.load(response.rendered_content, yaml.CLoader)
+    results = yaml.load(response.rendered_content, yaml.Loader)
     assert results["components"]["schemas"]["Sample"]["properties"]["field"] == {
         "title": "FieldSchema[List[tests.conftest.InnerSchema]]",
         "type": "array",
@@ -276,7 +276,7 @@ def test_openapi_parser_renderer_schema_generation(request_factory):
     request = request_factory.get("api/", format="json")
     response = schema_view(request)
 
-    results = yaml.load(response.rendered_content, yaml.CLoader)
+    results = yaml.load(response.rendered_content, yaml.Loader)
     assert results["paths"]["/api/"]["post"]["requestBody"]["content"][
         "application/json"
     ] == {

--- a/tests/test_e2e_models.py
+++ b/tests/test_e2e_models.py
@@ -1,0 +1,41 @@
+from datetime import date
+
+import pytest
+
+from .conftest import InnerSchema
+from .test_app.models import SampleModel
+
+
+@pytest.mark.parametrize(
+    "initial_payload,expected_values",
+    [
+        (
+            {
+                "sample_field": InnerSchema(stub_str="abc", stub_list=[date(2023, 6, 1)]),
+                "sample_list": [InnerSchema(stub_str="abc", stub_list=[])],
+            },
+            {
+                "sample_field": InnerSchema(stub_str="abc", stub_list=[date(2023, 6, 1)]),
+                "sample_list": [InnerSchema(stub_str="abc", stub_list=[])],
+            },
+        ),
+        (
+            {
+                "sample_field": {"stub_str": "abc", "stub_list": ['2023-06-01']},
+                "sample_list": [{"stub_str": "abc", "stub_list": []}],
+            },
+            {
+                "sample_field": InnerSchema(stub_str="abc", stub_list=[date(2023, 6, 1)]),
+                "sample_list": [InnerSchema(stub_str="abc", stub_list=[])],
+            },
+        ),
+    ],
+)
+@pytest.mark.django_db
+def test_model_e2e_serde(initial_payload, expected_values):
+    instance = SampleModel(**initial_payload)
+    instance.save()
+
+    instance = SampleModel.objects.get(pk=instance.pk)
+    instance_values = {k: getattr(instance, k) for k in expected_values.keys()}
+    assert instance_values == expected_values


### PR DESCRIPTION
Closes: #19 