### PR TITLE
Bring back JSON field lookups to work with schema [Django 4.2]

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e .[dev,rest]
+        python -m pip install -e .[dev,test]
     - name: Lint package
       run: mypy .
 
@@ -43,6 +43,27 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: pass
+          POSTGRES_DB: test_db
+        ports:
+          - 5432:5432
+      mariadb:
+        image: mariadb:11-jammy
+        env:
+          MARIADB_DATABASE: test_db
+          MYSQL_ROOT_PASSWORD: pass
+        ports:
+          - 3306:3306
+
+    env:
+      POSTGRES_DSN: postgresql://postgres:pass@127.0.0.1:5432/test_db
+      MYSQL_DSN: mysql://root:pass@127.0.0.1:3306/test_db
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -51,7 +72,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt update && sudo apt install -qy python3-dev default-libmysqlclient-dev build-essential
         python -m pip install --upgrade pip
-        python -m pip install -e .[dev,rest]
+        python -m pip install -e .[dev,test,ci]
     - name: Test package
       run: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-pydantic-field"
-version = "0.2.5"
+version = "0.2.6"
 description = "Django JSONField with Pydantic models as a Schema"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-rest = ["djangorestframework>=3,<4", "pyyaml"]
 dev = [
     "black",
     "isort",
@@ -54,6 +53,16 @@ dev = [
     "django-stubs[compatible-mypy]~=1.12.0",
     "djangorestframework-stubs[compatible-mypy]~=1.7.0",
     "pytest-django>=4.5,<5",
+]
+test = [
+    "dj-database-url~=2.0",
+    "djangorestframework>=3,<4",
+    "pyyaml",
+]
+ci = [
+    'psycopg[binary]>=3.1,<4; python_version>="3.9"',
+    'psycopg2-binary>=2.7,<3; python_version<"3.9"',
+    "mysqlclient>=2.1",
 ]
 
 [project.urls]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,9 @@ from datetime import date
 
 import pydantic
 import pytest
+
+from django.conf import settings
+from django.db import connections
 from pydantic.dataclasses import dataclass
 from rest_framework.test import APIRequestFactory
 
@@ -27,3 +30,51 @@ class SampleDataclass:
 @pytest.fixture
 def request_factory():
     return APIRequestFactory()
+
+
+# ==============================
+# PARAMETRIZED DATABASE BACKENDS
+# ==============================
+
+
+def sqlite_backend(_monkeypatch, _settings):
+    pass  # sqlite is our default database backend
+
+
+def postgres_backend(monkeypatch, settings):
+    settings.DATABASES["default"] = settings.DATABASES["postgres"]
+
+    with monkeypatch.context() as patch:
+        patch.setitem(connections, "default", connections["postgres"])
+        yield
+
+
+def mysql_backend(monkeypatch, settings):
+    settings.DATABASES["default"] = settings.DATABASES["mysql"]
+    with monkeypatch.context() as patch:
+        patch.setitem(connections, "default", connections["mysql"])
+        yield
+
+
+@pytest.fixture(
+    params=[
+        sqlite_backend,
+        pytest.param(
+            postgres_backend,
+            marks=pytest.mark.skipif(
+                "postgres" not in settings.DATABASES,
+                reason="POSTGRES_DSN is not specified",
+            ),
+        ),
+        pytest.param(
+            mysql_backend,
+            marks=pytest.mark.skipif(
+                "mysql" not in settings.DATABASES,
+                reason="MYSQL_DSN is not specified",
+            ),
+        ),
+    ]
+)
+def available_database_backends(request, django_db_blocker, monkeypatch, settings):
+    with django_db_blocker.unblock():
+        yield request.param(monkeypatch, settings)

--- a/tests/settings/django_test_settings.py
+++ b/tests/settings/django_test_settings.py
@@ -1,5 +1,6 @@
 import os
 import django
+import dj_database_url
 
 SECRET_KEY = "1"
 SITE_ID = 1
@@ -21,15 +22,14 @@ DATABASES = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(BASE_DIR, "settings", "db.sqlite3"),
     },
-    # "default": {
-    #     "ENGINE": "django.db.backends.postgresql",
-    #     "NAME": "test_db",
-    #     "USER": "postgres",
-    #     "PASSWORD": "pass",
-    #     "HOST": "127.0.0.1",
-    #     "PORT": 5432,
-    # }
 }
+
+if os.getenv("POSTGRES_DSN"):
+    DATABASES["postgres"] = dj_database_url.config("POSTGRES_DSN")  # type: ignore
+
+if os.getenv("MYSQL_DSN"):
+    DATABASES["mysql"] = dj_database_url.config("MYSQL_DSN")  # type: ignore
+
 
 REST_FRAMEWORK = {
     "COMPACT_JSON": True,

--- a/tests/settings/django_test_settings.py
+++ b/tests/settings/django_test_settings.py
@@ -20,7 +20,15 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(BASE_DIR, "settings", "db.sqlite3"),
-    }
+    },
+    # "default": {
+    #     "ENGINE": "django.db.backends.postgresql",
+    #     "NAME": "test_db",
+    #     "USER": "postgres",
+    #     "PASSWORD": "pass",
+    #     "HOST": "127.0.0.1",
+    #     "PORT": 5432,
+    # }
 }
 
 REST_FRAMEWORK = {

--- a/tests/test_e2e_models.py
+++ b/tests/test_e2e_models.py
@@ -2,6 +2,7 @@ from datetime import date
 
 import pytest
 
+from django.db.models import Q
 from .conftest import InnerSchema
 from .test_app.models import SampleModel
 
@@ -32,10 +33,57 @@ from .test_app.models import SampleModel
     ],
 )
 @pytest.mark.django_db
-def test_model_e2e_serde(initial_payload, expected_values):
+def test_model_db_serde(initial_payload, expected_values):
     instance = SampleModel(**initial_payload)
     instance.save()
 
     instance = SampleModel.objects.get(pk=instance.pk)
     instance_values = {k: getattr(instance, k) for k in expected_values.keys()}
     assert instance_values == expected_values
+
+
+@pytest.mark.parametrize(
+    "lookup",
+    [
+        Q(),
+        Q(sample_field=InnerSchema(stub_str="abc", stub_list=[date(2023, 6, 1)])),
+        Q(sample_field={"stub_str": "abc", "stub_list": ["2023-06-01"]}),
+        Q(sample_field__stub_int=1),
+        Q(sample_field__stub_str="abc"),
+        Q(sample_field__stub_list=[date(2023, 6, 1)]),
+    ],
+)
+@pytest.mark.django_db
+def test_model_field_lookup_succeeded(lookup):
+    instance = SampleModel(
+        sample_field=dict(stub_str="abc", stub_list=["2023-06-01"]),
+        sample_list=[],
+    )
+    instance.save()
+
+    filtered_instance = SampleModel.objects.get(lookup)
+    assert filtered_instance.pk == instance.pk
+
+
+@pytest.mark.parametrize(
+    "lookup",
+    [
+        Q(sample_field=InnerSchema(stub_str="abcd", stub_list=[date(2023, 6, 1)])),
+        Q(sample_field=InnerSchema(stub_str="abc", stub_list=[date(2023, 6, 2)])),
+        Q(sample_field={"stub_str": "abcd", "stub_list": ["2023-06-01"]}),
+        Q(sample_field={"stub_str": "abc", "stub_list": ["2023-06-02"]}),
+        Q(sample_field__stub_int=2),
+        Q(sample_field__stub_str="abcd"),
+        Q(sample_field__stub_list=[date(2023, 6, 2)]),
+    ],
+)
+@pytest.mark.django_db
+def test_model_field_lookup_failed(lookup):
+    instance = SampleModel(
+        sample_field=dict(stub_str="abc", stub_list=["2023-06-01"]),
+        sample_list=[],
+    )
+    instance.save()
+
+    with pytest.raises(SampleModel.DoesNotExist):
+        SampleModel.objects.get(lookup)

--- a/tests/test_e2e_models.py
+++ b/tests/test_e2e_models.py
@@ -6,6 +6,8 @@ from django.db.models import Q
 from .conftest import InnerSchema
 from .test_app.models import SampleModel
 
+pytestmark = [pytest.mark.usefixtures("available_database_backends")]
+
 
 @pytest.mark.parametrize(
     "initial_payload,expected_values",


### PR DESCRIPTION
With Django 4.2, JSON field has a bit more complex work done preparing the value for database.

Along with #21, 4.2 also brought the #19 live: prior 4.2 json data were serialized directly to string, now it may return a proper plain datastructure.

This PR mitigates this behavior, trying to encode the value obtained from `get_db_prep_value` with `SchemaEncoder` and loading it back to plain object, otherwise pass it per se -- this is most likely happens during lookup preparation, and full validation is performed on a higher level.