### PR TITLE
Django serialization support

### DIFF
--- a/django_pydantic_field/v1/fields.py
+++ b/django_pydantic_field/v1/fields.py
@@ -9,7 +9,7 @@ from django.db.models.fields import NOT_PROVIDED
 from django.db.models.fields.json import JSONField
 from django.db.models.query_utils import DeferredAttribute
 
-from django_pydantic_field.compat.django import GenericContainer, GenericTypes
+from django_pydantic_field.compat.django import GenericContainer
 
 from . import base, forms, utils
 
@@ -125,8 +125,9 @@ class PydanticSchemaField(JSONField, t.Generic[base.ST]):
         field_kwargs.update(kwargs)
         return super().formfield(**field_kwargs)
 
-    def value_from_object(self, obj):
-        return super().value_from_object().dict()
+    def value_to_string(self, obj):
+        value = self.value_from_object(obj)
+        return self.get_prep_value(value)
 
     def _resolve_schema(self, schema):
         schema = t.cast(t.Type["base.ST"], GenericContainer.unwrap(schema))

--- a/django_pydantic_field/v1/fields.py
+++ b/django_pydantic_field/v1/fields.py
@@ -125,6 +125,9 @@ class PydanticSchemaField(JSONField, t.Generic[base.ST]):
         field_kwargs.update(kwargs)
         return super().formfield(**field_kwargs)
 
+    def value_from_object(self, obj):
+        return super().value_from_object().dict()
+
     def _resolve_schema(self, schema):
         schema = t.cast(t.Type["base.ST"], GenericContainer.unwrap(schema))
 

--- a/django_pydantic_field/v2/fields.py
+++ b/django_pydantic_field/v2/fields.py
@@ -187,6 +187,9 @@ class PydanticSchemaField(JSONField, ty.Generic[types.ST]):
         field_kwargs.update(kwargs)
         return super().formfield(**field_kwargs)  # type: ignore
 
+    def value_from_object(self, obj):
+        return super().value_from_object().model_dump()
+
 
 class SchemaKeyTransformAdapter:
     """An adapter for creating key transforms for schema field lookups."""

--- a/tests/test_e2e_models.py
+++ b/tests/test_e2e_models.py
@@ -1,6 +1,7 @@
 from datetime import date
 
 import pytest
+from django.core import serializers
 from django.db.models import F, Q, JSONField, Value
 
 from tests.conftest import InnerSchema
@@ -44,6 +45,32 @@ def test_model_db_serde(initial_payload, expected_values):
     instance = SampleModel.objects.get(pk=instance.pk)
     instance_values = {k: getattr(instance, k) for k in expected_values.keys()}
     assert instance_values == expected_values
+
+
+@pytest.mark.parametrize("format", ["python", "json", "yaml", "jsonl"])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "sample_field": InnerSchema(stub_str="abc", stub_list=[date(2023, 6, 1)]),
+            "sample_list": [InnerSchema(stub_str="abc", stub_list=[])],
+        },
+        {
+            "sample_field": {"stub_str": "abc", "stub_list": ["2023-06-01"]},
+            "sample_list": [{"stub_str": "abc", "stub_list": []}],
+        },
+    ],
+)
+def test_model_serialization(payload, format):
+    instance = SampleModel(**payload)
+    instance_values = {k: getattr(instance, k) for k in payload.keys()}
+
+    serialized_instances = serializers.serialize(format, [instance])
+    deserialized_instance = next(serializers.deserialize(format, serialized_instances)).object
+    deserialized_values = {k: getattr(deserialized_instance, k) for k in payload.keys()}
+
+    assert instance_values == deserialized_values
+    assert serialized_instances == serializers.serialize(format, [deserialized_instance])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Django has built-in [serializers](https://docs.djangoproject.com/en/5.0/topics/serialization/). To support serializing Django models which contain PydanticSchemaField it is necessary to re-implement [value_from_object()](https://docs.djangoproject.com/en/5.0/ref/models/fields/#django.db.models.Field.value_from_object). Without this fix Django serialization encounters errors if a model contains PydanticSchemaField fields.