### PR TITLE
Removed a dangling import which is causing the install to fail in v0.3.5 and v0.3.6

### DIFF
--- a/django_pydantic_field/compat/django.py
+++ b/django_pydantic_field/compat/django.py
@@ -35,7 +35,6 @@ import typing_extensions as te
 from django.db.migrations.serializer import BaseSerializer, serializer_factory
 from django.db.migrations.writer import MigrationWriter
 from pydantic.fields import FieldInfo
-from pydantic_core import PydanticUndefined
 
 from .pydantic import PYDANTIC_V1
 from .typing import get_args, get_origin


### PR DESCRIPTION
**Encountering the following error while installing django-pydantic-field v0.3.5 and v0.3.6**

Traceback

```
[stderr] apps.populate(settings.INSTALLED_APPS)
[stderr] File "/usr/local/lib/python3.11/site-packages/django/apps/registry.py", line 116, in populate
[stderr] app_config.import_models()
[stderr] File "/usr/local/lib/python3.11/site-packages/django/apps/config.py", line 269, in import_models
[stderr] self.models_module = import_module(models_module_name)
[stderr] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[stderr] File "/usr/local/lib/python3.11/importlib/__init__.py", line 126, in import_module
[stderr] return _bootstrap._gcd_import(name[level:], package, level)
[stderr] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[stderr] File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
[stderr] File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
[stderr] File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
[stderr] File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
[stderr] File "<frozen importlib._bootstrap_external>", line 940, in exec_module
[stderr] File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
[stderr] File "/web/user_profiles/models.py", line 11, in <module>
[stderr] from django_pydantic_field import SchemaField
[stderr] File "/usr/local/lib/python3.11/site-packages/django_pydantic_field/__init__.py", line 1, in <module>
[stderr] from .fields import SchemaField as SchemaField
[stderr] File "/usr/local/lib/python3.11/site-packages/django_pydantic_field/fields.py", line 1, in <module>
[stderr] from .compat.imports import compat_dir, compat_getattr
[stderr] File "/usr/local/lib/python3.11/site-packages/django_pydantic_field/compat/__init__.py", line 1, in <module>
[stderr] from .django import GenericContainer as GenericContainer
[stderr] File "/usr/local/lib/python3.11/site-packages/django_pydantic_field/compat/django.py", line 38, in <module>
[stderr] from pydantic_core import PydanticUndefined
[stderr]ModuleNotFoundError: No module named 'pydantic_core'
```

The issue was an unhandled import. The removal of this import won't break anything because this import is already in a try catch block. Here: https://github.com/surenkov/django-pydantic-field/blob/8ae552fe80fe1fc0f2cb930b6754a100e3166e97/django_pydantic_field/compat/django.py#L45 and here: https://github.com/surenkov/django-pydantic-field/blob/8ae552fe80fe1fc0f2cb930b6754a100e3166e97/django_pydantic_field/compat/django.py#L48