### PR TITLE
Bypass field validation on model instantiation if it does not contain a `default=` argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,45 @@
- DJANGO_SETTINGS_MODULE ?= "tests.settings.django_test_settings"
+export DJANGO_SETTINGS_MODULE=tests.settings.django_test_settings
 
-.PHONY: install build test lint upload upload-test clean
-
+.PHONY: install
 install:
 	python3 -m pip install build twine
 	python3 -m pip install -e .[dev,test]
 
+.PHONY: build
 build:
 	python3 -m build
 
+.PHONY: migrations
 migrations:
 	python3 -m django makemigrations --noinput
 
+.PHONY: runserver
 runserver:
 	python3 -m django migrate && \
 	python3 -m django runserver
 
+.PHONY: check
+check:
+	python3 -m django check
+
+.PHONY: test
 test: A=
 test:
 	pytest $(A)
 
+.PHONY: lint
 lint: A=.
 lint:
 	python3 -m mypy $(A)
 
+.PHONY: upload
 upload:
 	python3 -m twine upload dist/*
 
+.PHONY: upload-test
 upload-test:
 	python3 -m twine upload --repository testpypi dist/*
 
+.PHONY: clean
 clean:
 	rm -rf dist/*

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -314,3 +314,10 @@ def test_copy_field():
     assert copied.name == Building.meta.field.name
     assert copied.attname == Building.meta.field.attname
     assert copied.concrete == Building.meta.field.concrete
+
+
+def test_model_init_no_default():
+    try:
+        SampleModel()
+    except Exception:
+        pytest.fail("Model with schema field without a default value should be able to initialize")


### PR DESCRIPTION
Closes #58 