### PR TITLE
Use plain exception strings when throwing `django.core.exceptions.ValidationError`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: check-hooks-apply
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.4.3
+    rev: v0.9.1
     hooks:
       # Run the linter.
       - id: ruff

--- a/django_pydantic_field/v1/fields.py
+++ b/django_pydantic_field/v1/fields.py
@@ -81,7 +81,7 @@ class PydanticSchemaField(JSONField, t.Generic[base.ST]):
             assert self.decoder is not None
             return self.decoder().decode(value)
         except pydantic.ValidationError as e:
-            raise django_exceptions.ValidationError(e.errors())
+            raise django_exceptions.ValidationError(str(e)) from e
 
     def get_prep_value(self, value):
         if not self._is_prepared_schema:

--- a/django_pydantic_field/v2/fields.py
+++ b/django_pydantic_field/v2/fields.py
@@ -170,8 +170,7 @@ class PydanticSchemaField(JSONField, ty.Generic[types.ST]):
         try:
             return self.adapter.validate_python(value)
         except pydantic.ValidationError as exc:
-            error_params = {"errors": exc.errors(), "field": self}
-            raise exceptions.ValidationError(exc.json(), code="invalid", params=error_params) from exc
+            raise exceptions.ValidationError(str(exc), code="invalid") from exc
 
     def get_prep_value(self, value: ty.Any):
         value = self._prepare_raw_value(value)


### PR DESCRIPTION
Closes #77 