### PR TITLE
Partial fix for Python 3.14.

### DIFF
--- a/django_pydantic_field/v2/utils.py
+++ b/django_pydantic_field/v2/utils.py
@@ -9,13 +9,20 @@ from django_pydantic_field.compat import typing
 if ty.TYPE_CHECKING:
     from collections.abc import Mapping
 
+try:
+    from annotationlib import get_annotations  # Python >= 3.14
+except ImportError:
+
+    def get_annotations(obj):
+        if isinstance(obj, type):
+            return obj.__dict__["__annotations__"]
+        else:
+            return obj.__annotations__
+
 
 def get_annotated_type(obj, field, default=None) -> ty.Any:
     try:
-        if isinstance(obj, type):
-            annotations = obj.__dict__["__annotations__"]
-        else:
-            annotations = obj.__annotations__
+        annotations = get_annotations(obj)
 
         return annotations[field]
     except (AttributeError, KeyError):


### PR DESCRIPTION
This fixes the behavior of `get_annotated_type` in Python 3.14. There are other issues with Python 3.14 which need to be fixed (serialization for migrations), but I haven't had time for those. Most tests now pass in Python 3.14.