### PR TITLE
Add DjangoPydanticJSONEncoder as the default encoder

### DIFF
--- a/django_pydantic_field/v2/fields.py
+++ b/django_pydantic_field/v2/fields.py
@@ -54,6 +54,15 @@ if ty.TYPE_CHECKING:
 __all__ = ("SchemaField",)
 
 
+class PydanticDjangoJSONEncoder(DjangoJSONEncoder):
+    """DjangoJSONEncoder subclass that adds support for Pydantic models."""
+
+    def default(self, o):
+        if isinstance(o, pydantic.BaseModel):
+            return o.model_dump(mode='json')
+        return super().default(o)
+
+
 class SchemaAttribute(DeferredAttribute):
     field: PydanticSchemaField
 
@@ -81,7 +90,7 @@ class PydanticSchemaField(JSONField, ty.Generic[types.ST]):
         config: pydantic.ConfigDict | None = None,
         **kwargs,
     ):
-        kwargs.setdefault("encoder", DjangoJSONEncoder)
+        kwargs.setdefault("encoder", PydanticDjangoJSONEncoder)
         self.export_kwargs = export_kwargs = types.SchemaAdapter.extract_export_kwargs(kwargs)
         super().__init__(*args, **kwargs)
 

--- a/django_pydantic_field/v2/fields.py
+++ b/django_pydantic_field/v2/fields.py
@@ -59,7 +59,7 @@ class PydanticDjangoJSONEncoder(DjangoJSONEncoder):
 
     def default(self, o):
         if isinstance(o, pydantic.BaseModel):
-            return o.model_dump(mode='json')
+            return o.model_dump(mode="json")
         return super().default(o)
 
 


### PR DESCRIPTION
This uses a default which just serializes the model without any extra parameters. If users want the behaviour to be different, they can still override it using the kwarg, but now the default won't throw an exception if used to serialize the field to JSON anymore.

closes #86 