### PR TITLE
Fix migration serialization for Pydantic constraints and dataclasses

### DIFF
--- a/src/django_pydantic_field/compat/django.py
+++ b/src/django_pydantic_field/compat/django.py
@@ -90,6 +90,8 @@ class GenericContainer(BaseContainer):
         if isinstance(value, GenericTypes):
             wrapped_args = tuple(map(cls.wrap, get_args(value)))
             return cls(get_origin(value), wrapped_args)
+        if DataclassContainer.is_dataclass_instance(value):
+            return DataclassContainer.wrap(value)
         if isinstance(value, FieldInfo):
             return FieldInfoContainer.wrap(value)
         return value
@@ -129,7 +131,7 @@ class DataclassContainer(BaseContainer):
 
     @classmethod
     def wrap(cls, value):
-        if cls._is_dataclass_instance(value):
+        if cls.is_dataclass_instance(value):
             return cls(type(value), dataclasses.asdict(value))
         if isinstance(value, GenericTypes):
             return GenericContainer.wrap(value)
@@ -142,11 +144,11 @@ class DataclassContainer(BaseContainer):
         return value
 
     @staticmethod
-    def _is_dataclass_instance(obj: ty.Any):
+    def is_dataclass_instance(obj: ty.Any):
         return dataclasses.is_dataclass(obj) and not isinstance(obj, type)
 
     def __eq__(self, other):
-        if self._is_dataclass_instance(other):
+        if self.is_dataclass_instance(other):
             return self == self.wrap(other)
         return super().__eq__(other)
 
@@ -292,7 +294,7 @@ class RepresentationSerializer(BaseSerializer):
                 repr_args.append(f"{arg_name}={arg_value_repr}")
 
         final_args_repr = ", ".join(repr_args)
-        return f"{tp_repr}({final_args_repr})"
+        return f"{tp_repr}({final_args_repr})", imports
 
 
 AnnotatedAlias = te._AnnotatedAlias


### PR DESCRIPTION
Pydantic v2 types like `conint` and `StringConstraints` use internal objects (e.g., `annotated_types.Gt`) that Django cannot serialize by default. By ensuring `GenericContainer` wraps these dataclass-like instances and fixing the `RepresentationSerializer` to return necessary imports, these types can now be used in Django migrations.

Addresses #72, but only for Pydantic v2. Pydantic v1 requires a different approach as it generates the ad-hoc constrained types, and in light of #35 and #71, not worth an effort.