### PR TITLE
Fix infinite recursion in migration serialization for union types on Python 3.11+

### DIFF
--- a/tests/test_migration_serializers.py
+++ b/tests/test_migration_serializers.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import annotated_types
 import pytest
 from django.db.migrations.writer import MigrationWriter
-from pydantic import SecretStr, conint, constr
+from pydantic import BaseModel, SecretStr, conint, constr
 from typing_extensions import Annotated
 
 from django_pydantic_field.compat import PYDANTIC_V1
@@ -22,6 +22,10 @@ class SampleDataclass:
     tp: ty.Any
 
 
+class SampleModel(BaseModel):
+    name: str
+
+
 test_types = [
     str,
     list,
@@ -33,6 +37,8 @@ test_types = [
     ty.ForwardRef("str"),
     SecretStr,
     Annotated[int, annotated_types.Gt(gt=0)],
+    list[SampleModel] | None,
+    ty.Union[list[SampleModel], None],
     SampleDataclass,
     pytest.param(
         conint(gt=0),


### PR DESCRIPTION
The issue stems from modern versions of Python identifying generic aliases (like `list[ComplexModel]`) as iterables. This trips up Django's migration writer, which tries to iterate through the type itself and gets stuck in a loop. 

I’ve updated the union serializer to wrap these arguments in a `GenericContainer` so they're handled by the custom logic instead of Django's default serializers.

Closes #98 